### PR TITLE
Fix bug where an exam would be counted multiple times towards the total

### DIFF
--- a/src/components/result-list/student-result.tsx
+++ b/src/components/result-list/student-result.tsx
@@ -19,7 +19,7 @@ export const StudentResults = ({ student, language, studentBaseUrl }: StudentRes
   const [totalGradePoints, setTotalGradePoints] = useState<number>()
 
   useEffect(() => {
-    const addIncludedExamPoints = (gradePoints: number) => {
+    const addIncludedExamPoints = (gradePoints: number, examsWithBestGrades: Exam[]) => {
       if (!student.includedExams) {
         return gradePoints
       }
@@ -36,7 +36,7 @@ export const StudentResults = ({ student, language, studentBaseUrl }: StudentRes
 
     const calculatedGradePoints = examsWithBestGrades.reduce((total, exam) => exam.gradePoints + total, 0)
 
-    setTotalGradePoints(addIncludedExamPoints(calculatedGradePoints))
+    setTotalGradePoints(addIncludedExamPoints(calculatedGradePoints, examsWithBestGrades))
     setExams(groupExams(student.exams))
   }, [student])
 


### PR DESCRIPTION
The old implementation would iterate through the exams of the student, and for each exam it would compare the scores for possible included exams. This would mean that if the student had multiple instances of the same exam whose score was lower than the included exam, the included exam score would be counted towards the total multiple times.

To fix this, I first filter the exams of the student to contain only the ones with the best score. Then I iterate through the included exams and check if the exam has already been included in the count. If not, it gets included. This should fix both the original bug and this new regression.